### PR TITLE
Quick fixes: scai-gen/fileio/common.go and test-sigstore-integration.yml

### DIFF
--- a/.github/workflows/test-sigstore-integration.yml
+++ b/.github/workflows/test-sigstore-integration.yml
@@ -35,7 +35,6 @@ jobs:
 
       - name: Sign and upload SCAI report (Sigstore)
         id: sign-report
-        shell: bash
         uses: ./.github/actions/scai-gen-sigstore
         with:
           statement-file: examples/sbom+slsa/metadata/evidence-collection.scai.json

--- a/scai-gen/fileio/common.go
+++ b/scai-gen/fileio/common.go
@@ -13,5 +13,5 @@ func HasJSONExt(filename string) bool {
 func CreateOutDir(filename string) error {
 	outDir := filepath.Dir(filename)
 
-	return os.MkdirAll(outDir, 0644)
+	return os.MkdirAll(outDir, 0755)
 }


### PR DESCRIPTION
This PR is a quick patch to fix two issues. 1) Set RWX permissions for new directories created during any `scai-gen` command. These permissions are needed to create files within these new directories. 2) There's a syntax error in the Sigstore test workflow.