### PR TITLE
Fix Sigstore Action bug

### DIFF
--- a/.github/actions/scai-gen-sigstore/action.yml
+++ b/.github/actions/scai-gen-sigstore/action.yml
@@ -40,6 +40,6 @@ runs:
       id: upload-signed
       uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
       with:
-        name: ${{ steps.sign.inputs.attestation-name }}
+        name: ${{ inputs.attestation-name }}
         path: ${{ steps.sign.outputs.attestation-name }}
         retention-days: 15


### PR DESCRIPTION
There's a bug in the input to the upload-artifact Action in the scai-gen-sigstore Action, which prevents the signed attestation from being uploaded as a workflow artifact.