### PR TITLE
Update the Python file hashing API to securesystemslib.hash.digest_filename

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ $(PYTHON_DIR):
 	. $(abspath $(VENVDIR)/bin/activate) && pip install --upgrade pip
 	. $(abspath $(VENVDIR)/bin/activate) && pip install --upgrade wheel
 	. $(abspath $(VENVDIR)/bin/activate) && pip install --upgrade in-toto
-	. $(abspath $(VENVDIR)/bin/activate) && pip install --upgrade in-toto-attestation>=0.9.2
+	. $(abspath $(VENVDIR)/bin/activate) && pip install --upgrade in-toto-attestation>=0.9.3
 	. $(abspath $(VENVDIR)/bin/activate) && pip install --upgrade ./python
 
 $(VENVDIR):

--- a/examples/gcc-helloworld/run-example.sh
+++ b/examples/gcc-helloworld/run-example.sh
@@ -3,7 +3,6 @@
 # Copyright 2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-VENV_DIR="${VENVDIR:=../../scai-venv}"
 EXAMPLE_DIR=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 
 # -----------------------------------------------------------------
@@ -11,8 +10,6 @@ EXAMPLE_DIR=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 # -----------------------------------------------------------------
 
 mkdir -p ${EXAMPLE_DIR}/metadata
-
-source ${VENV_DIR}/bin/activate
 
 echo RUN GCC
 

--- a/python/scai_generator/cli/gen_attr_assertion.py
+++ b/python/scai_generator/cli/gen_attr_assertion.py
@@ -28,8 +28,6 @@ from in_toto_attestation.v1.resource_descriptor import ResourceDescriptor
 
 import google.protobuf.json_format as pb_json
 
-from securesystemslib.util import get_file_hashes
-
 def Main():
     parser = argparse.ArgumentParser(allow_abbrev=False)
 

--- a/python/scai_generator/cli/gen_resource_desc.py
+++ b/python/scai_generator/cli/gen_resource_desc.py
@@ -23,7 +23,7 @@ import os
 from scai_generator.utility import load_json_file
 from in_toto_attestation.v1.resource_descriptor import ResourceDescriptor
 
-from securesystemslib.util import get_file_hashes
+from securesystemslib.hash import digest_filename
 import google.protobuf.json_format as pb_json
 
 def Main():
@@ -57,7 +57,10 @@ def Main():
     
     resource_digest_set = {}
     if options.digest and resource_file_path:
-        resource_digest_set = get_file_hashes(resource_file_path)
+        # we're ok with using the default hash algorithm (sha256)
+        hash_obj = digest_filename(resource_file_path)
+        # convert the hash object into a digest set
+        resource_digest_set.update({hash_obj.name: hash_obj.hexdigest()})
 
     resource_bytes = bytes()
     if options.content and resource_file_path:


### PR DESCRIPTION
This API change is needed ahead of the removal of the old `get_file_hashes()` API from securesystemslibs (see https://github.com/secure-systems-lab/securesystemslib/pull/773).