### PR TITLE
Bump SCAI predicate version to v0.3

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,4 +24,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ec5d18412c0aeab7936cb16880d708ba2a64e1ae
         with:
-          version: v1.54.2
+          version: v1.60.3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a
         with:
-          go-version: '1.21.x'
+          go-version: '1.22.x'
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ec5d18412c0aeab7936cb16880d708ba2a64e1ae

--- a/.github/workflows/test-e2e-flow.yml
+++ b/.github/workflows/test-e2e-flow.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
 
       - name: Checkout updated scai-gen CLI tools
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/in-toto/scai-demos
 
-go 1.22.5
+go 1.22.8
 
 toolchain go1.22.9
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/in-toto/scai-demos
 
-go 1.21
+go 1.22.5
+
 toolchain go1.22.9
 
 require (

--- a/scai-gen/cmd/check.go
+++ b/scai-gen/cmd/check.go
@@ -294,11 +294,7 @@ func isSupportedPredicateType(predicateType string) bool {
 		idx := slices.IndexFunc(supportedTypes, func(v string) bool {
 			return v == version
 		})
-
-		if idx > -1 {
-			return true
-		}
-		return false
+		return idx > -1
 	}
 	return false
 }

--- a/scai-gen/cmd/check.go
+++ b/scai-gen/cmd/check.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/in-toto/scai-demos/scai-gen/pkg/fileio"
@@ -156,7 +157,7 @@ func checkEvidence(_ *cobra.Command, args []string) error {
 		return fmt.Errorf("failed read evidence files in directory %s: %w", evidenceDir, err)
 	}
 
-	if statement.GetPredicateType() != "https://in-toto.io/attestation/scai/attribute-report/v0.2" {
+	if !isSupportedPredicateType(statement.GetPredicateType()) {
 		return fmt.Errorf("evidence checking only supported for SCAI attestations")
 	}
 
@@ -281,4 +282,23 @@ func getAllEvidenceFiles(evidenceDir string) (map[string][]byte, error) {
 	}
 
 	return evidenceMap, nil
+}
+
+func isSupportedPredicateType(predicateType string) bool {
+	supportedTypes := []string{"attribute-report/v0.2", "v0.3"}
+
+	// TODO: a future version of the scai Go package will have a const for this URI
+	version, found := strings.CutPrefix(predicateType, "https://in-toto.io/attestation/scai/")
+
+	if found {
+		idx := slices.IndexFunc(supportedTypes, func(v string) bool {
+			return v == version
+		})
+
+		if idx > -1 {
+			return true
+		}
+		return false
+	}
+	return false
 }

--- a/scai-gen/cmd/report.go
+++ b/scai-gen/cmd/report.go
@@ -23,6 +23,7 @@ var reportCmd = &cobra.Command{
 var (
 	subjectFile  string
 	producerFile string
+	version      string
 )
 
 func init() {
@@ -50,6 +51,14 @@ func init() {
 		"p",
 		"",
 		"The filename of the JSON-encoded producer resource descriptor",
+	)
+
+	reportCmd.Flags().StringVarP(
+		&version,
+		"version",
+		"v",
+		"v0.3",
+		"The spec version to generate for the generated attribute report",
 	)
 
 	reportCmd.Flags().BoolVarP(
@@ -115,7 +124,16 @@ func genAttrReport(_ *cobra.Command, args []string) error {
 		return err
 	}
 
-	statement, err := generators.NewStatement([]*ita.ResourceDescriptor{subject}, "https://in-toto.io/attestation/scai/attribute-report/v0.2", reportStruct)
+	// TODO: a future version of the scai Go package will have a const for this URI
+	predicateType := "https://in-toto.io/attestation/scai/"
+	if version == "v0.2" {
+		suffix := "attribute-report/v0.2"
+		predicateType += suffix
+	} else {
+		predicateType += version
+	}
+
+	statement, err := generators.NewStatement([]*ita.ResourceDescriptor{subject}, predicateType, reportStruct)
 	if err != nil {
 		return fmt.Errorf("unable to generate in-toto Statement: %w", err)
 	}


### PR DESCRIPTION
This PR introduces corresponding tooling changes following https://github.com/in-toto/attestation/pull/380 .